### PR TITLE
Update Airbrake Heroku addon name

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,7 +11,7 @@
     "heroku-postgresql:hobby-dev",
     "papertrail:choklad",
     "newrelic:wayne",
-    "airbrake:free_heroku"
+    "airbrake:free-hrku"
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
Airbrake has changed the name of their free plan on Heroku.
